### PR TITLE
Use lower case import path for logrus

### DIFF
--- a/ginerus.go
+++ b/ginerus.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 func Ginerus() gin.HandlerFunc {


### PR DESCRIPTION
Due to some import problems the author of logrus encourages users to
use all lower case paths. Cf. a [comment on the respective issue on the
logrus
repository](https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276)